### PR TITLE
Bump `tui` to 0.14 in order to resolve build issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 
 [dependencies]
 crossterm = { version = "0.18", features = ["event-stream"] }
-tui = { version = "0.12", default-features = false, features = ['crossterm'] }
+tui = { version = "0.14", default-features = false, features = ['crossterm'] }
 tui-logger = { version = "0.4", default-features = false, features = ["tui-crossterm"] }
 log = "0.4.11"
 nats = "0.9.1"


### PR DESCRIPTION
Resolves the issue below when building:
```
Compiling nats-spy v0.1.1 
error[E0308]: mismatched types
   --> src/application.rs:253:46
    |
253 |             TuiLoggerWidget::default().block(Block::default().title("Logs").borders(Borders::ALL));
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `tui::widgets::block::Block`, found struct `tui::widgets::Block`
    |
    = note: perhaps two different versions of crate `tui` are being used?

error[E0277]: the trait bound `TuiLoggerWidget<'_>: Widget` is not satisfied
   --> src/application.rs:329:11
    |
329 |         f.render_widget(logs, left_chunk[6]);
    |           ^^^^^^^^^^^^^ the trait `Widget` is not implemented for `TuiLoggerWidget<'_>`

Some errors have detailed explanations: E0277, E0308.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `nats-spy` due to 2 previous errors
```

`tui-logger` @ 0.4.13 requires `tui` `0.14:
https://crates.io/crates/tui-logger/0.4.13/dependencies 